### PR TITLE
Add missed param - "model_name"

### DIFF
--- a/self_instruct/configs/llama_7b_lora.json
+++ b/self_instruct/configs/llama_7b_lora.json
@@ -26,6 +26,7 @@
     },
     "load_in_8bit": true,
     "only_target_loss": false,
+    "model_name": "models/llama-7b-hf",
     "templates_path": "internal_prompts/ru_alpaca.json",
     "model_type": "causal",
     "max_source_tokens_count": 256,


### PR DESCRIPTION
Avoid error caused by missing model_name:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/mnt/r/rulm/self_instruct/src/train.py", line 259, in <module>
    train(**vars(args))
  File "/mnt/r/rulm/self_instruct/src/train.py", line 106, in train
    model_name = config["model_name"]
```

E.g. this param is in 13b: https://github.com/IlyaGusev/rulm/blob/master/self_instruct/configs/llama_13b_lora.json#L29