### PR TITLE
fix mode to avoid referenced before assignment error 

### DIFF
--- a/self_instruct/src/train.py
+++ b/self_instruct/src/train.py
@@ -203,7 +203,7 @@ def train(
 
     # Default model generation params
     model.config.num_beams = 5
-    if mode == "instruction":
+    if mode == "instruct":
         max_tokens_count = max_target_tokens_count + max_source_tokens_count + 1
     model.config.max_length = max_tokens_count if model_type == "causal" else max_target_tokens_count
 


### PR DESCRIPTION
You defined mode as `"instruct"` for  `model_type = 'causal'`
```python
  mode = config.get("mode", "instruct")
  if mode == "instruct":
      max_source_tokens_count = config["max_source_tokens_count"]
     <...>
```
but later 

```python
if mode == "instruction":
        max_tokens_count = max_target_tokens_count + max_source_tokens_count + 1
    model.config.max_length = max_tokens_count if model_type == "causal" else max_target_tokens_count
```
it causes referenced before assignment error (`max_tokens_count` will never be defined)