### PR TITLE
small_fixes_imports_fp16_train

### DIFF
--- a/self_instruct/src/benchmarks/eval_lora_rsg.py
+++ b/self_instruct/src/benchmarks/eval_lora_rsg.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Tuple
 import fire
 
-from src.eval_rsg import (
+from src.benchmarks.eval_zs_rsg import (
     predict_danetqa,
     predict_rcb,
     predict_terra,

--- a/self_instruct/src/data_processing/convert_rsg.py
+++ b/self_instruct/src/data_processing/convert_rsg.py
@@ -5,7 +5,7 @@ from itertools import chain
 
 from datasets import load_dataset
 
-from src.eval_rsg import (
+from src.benchmarks.eval_zs_rsg import (
     RWSD_PROMPT,
     TERRA_PROMPT,
     MUSERC_SINGLE_PROMPT,

--- a/self_instruct/src/train.py
+++ b/self_instruct/src/train.py
@@ -212,8 +212,14 @@ def train(
         model = prepare_model_for_kbit_training(model)
 
     else:
-        model = model_types[model_type].from_pretrained(model_name)
-        model = fix_model(model, tokenizer)
+        model = model_types[model_type].from_pretrained(
+            model_name, 
+            device_map=device_map, 
+            torch_dtype=torch_dtype,
+            use_flash_attention_2=use_flash_attention_2
+        )
+        model = fix_model(model, tokenizer, use_resize=False)
+        model = custom_prepare_model_for_int8_training(model)
 
     # Default model generation params
     model.config.num_beams = 5


### PR DESCRIPTION
Фиксы импортов + ветка в условном операторе в train.py для обучения в случае с fp16 была заброшена, дополнил в соответствии с веткой в load_in_8bit.