### PR TITLE
Enhancements to Training Configurations and Script

### DIFF
--- a/self_instruct/configs/mistral_7b_128k.json
+++ b/self_instruct/configs/mistral_7b_128k.json
@@ -1,0 +1,37 @@
+{
+    "trainer": {
+        "evaluation_strategy": "steps",
+        "per_device_train_batch_size": 2,
+        "per_device_eval_batch_size": 2,
+        "gradient_accumulation_steps": 64,
+        "eval_steps": 50,
+        "save_steps": 50,
+        "logging_steps": 5,
+        "learning_rate": 0.00025,
+        "num_train_epochs": 4,
+        "lr_scheduler_type": "cosine",
+        "warmup_steps": 30,
+        "fp16": false,
+        "bf16": true,
+        "torch_compile": false,
+        "optim": "adamw_torch"
+    },
+    "lora": {
+        "r": 16,
+        "lora_alpha": 16,
+        "lora_dropout": 0.05,
+        "bias": "none",
+        "target_modules": ["q_proj", "v_proj", "k_proj", "o_proj"],
+        "task_type": "CAUSAL_LM"
+    },
+    "use_flash_attention_2": true,
+    "load_in_8bit": false,
+    "load_in_4bit": true,
+    "only_target_loss": true,
+    "mode": "chat",
+    "templates_path": "internal_prompts/saiga_v2.json",
+    "model_name": "models/Yarn-Mistral-7b-128k",
+    "model_type": "causal",
+    "max_tokens_count": 2000
+}
+

--- a/self_instruct/configs/mpt_30b.json
+++ b/self_instruct/configs/mpt_30b.json
@@ -1,0 +1,36 @@
+{
+    "trainer": {
+        "evaluation_strategy": "steps",
+        "per_device_train_batch_size": 4,
+        "per_device_eval_batch_size": 4,
+        "gradient_accumulation_steps": 8,
+        "eval_steps": 3,
+        "save_steps": 3,
+        "logging_steps": 1,
+        "learning_rate": 0.0001,
+        "num_train_epochs": 2,
+        "lr_scheduler_type": "cosine",
+        "warmup_steps": 3,
+        "fp16": false,
+        "bf16": true,
+        "torch_compile": false,
+        "optim": "adamw_torch"
+    },
+    "lora": {
+        "r": 8,
+        "lora_alpha": 16,
+        "lora_dropout": 0.05,
+        "bias": "none",
+        "target_modules": ["up_proj", "down_proj"],
+        "task_type": "CAUSAL_LM"
+    },
+    "load_in_8bit": true,
+    "load_in_4bit": false,
+    "only_target_loss": true,
+    "mode": "chat",
+    "templates_path": "internal_prompts/saiga_v2.json",
+    "model_name": "models/mpt-3b",
+    "tokenizer_name": "EleutherAI/gpt-neox-30b",
+    "model_type": "causal",
+    "max_tokens_count": 8192
+}

--- a/self_instruct/configs/mpt_7b_8k.json
+++ b/self_instruct/configs/mpt_7b_8k.json
@@ -1,0 +1,36 @@
+{
+    "trainer": {
+        "evaluation_strategy": "steps",
+        "per_device_train_batch_size": 4,
+        "per_device_eval_batch_size": 4,
+        "gradient_accumulation_steps": 8,
+        "eval_steps": 3,
+        "save_steps": 3,
+        "logging_steps": 1,
+        "learning_rate": 0.0001,
+        "num_train_epochs": 2,
+        "lr_scheduler_type": "cosine",
+        "warmup_steps": 3,
+        "fp16": false,
+        "bf16": true,
+        "torch_compile": false,
+        "optim": "adamw_torch"
+    },
+    "lora": {
+        "r": 8,
+        "lora_alpha": 16,
+        "lora_dropout": 0.05,
+        "bias": "none",
+        "target_modules": ["up_proj", "down_proj"],
+        "task_type": "CAUSAL_LM"
+    },
+    "load_in_8bit": true,
+    "load_in_4bit": false,
+    "only_target_loss": true,
+    "mode": "chat",
+    "templates_path": "internal_prompts/saiga_v2.json",
+    "model_name": "models/mpt-7b-8k",
+    "tokenizer_name": "EleutherAI/gpt-neox-20b",
+    "model_type": "causal",
+    "max_tokens_count": 8192
+}

--- a/self_instruct/configs/mpt_7b_storywriter.json
+++ b/self_instruct/configs/mpt_7b_storywriter.json
@@ -1,0 +1,36 @@
+{
+    "trainer": {
+        "evaluation_strategy": "steps",
+        "per_device_train_batch_size": 4,
+        "per_device_eval_batch_size": 4,
+        "gradient_accumulation_steps": 8,
+        "eval_steps": 3,
+        "save_steps": 3,
+        "logging_steps": 1,
+        "learning_rate": 0.0001,
+        "num_train_epochs": 2,
+        "lr_scheduler_type": "cosine",
+        "warmup_steps": 3,
+        "fp16": false,
+        "bf16": true,
+        "torch_compile": false,
+        "optim": "adamw_torch"
+    },
+    "lora": {
+        "r": 8,
+        "lora_alpha": 16,
+        "lora_dropout": 0.05,
+        "bias": "none",
+        "target_modules": ["up_proj", "down_proj"],
+        "task_type": "CAUSAL_LM"
+    },
+    "load_in_8bit": true,
+    "load_in_4bit": false,
+    "only_target_loss": true,
+    "mode": "chat",
+    "templates_path": "internal_prompts/saiga_v2.json",
+    "model_name": "models/mpt-7b-storywriter",
+    "tokenizer_name": "EleutherAI/gpt-neox-20b",
+    "model_type": "causal",
+    "max_tokens_count": 65536
+}


### PR DESCRIPTION
Dear Authors of the rulm Project,

I want to express my profound gratitude for your exceptional work on the rulm project and I am excited to propose some enhancements that could further augment its capabilities.

**New Configurations Added**

* self_instruct/configs/mistral_7b_128k.json
* self_instruct/configs/mpt_30b.json
* self_instruct/configs/mpt_7b_8k.json
* self_instruct/configs/mpt_7b_storywriter.json

These configurations are designed to add support of more models.

**Modifications to self_instruct/src/train.py**

I have incorporated support for new options in the train.py script, which include:

* `tokenizer_name` - this option allows the use of a tokenizer different from the model. For instance, while training MosaicML MPT models, the EleutherAI/gpt-neox-20b tokenizer is utilized, even though the model name might be something like mosaicml/mpt-7b-storywriter;
* `use_fast` - as the tokenizer used in MPT models does not operate if use_fast=False, this addition ensures smoother functionality.
* `use_flash_attention_2` support for 4-bit training mode - this enhancement is introduced to optimize training efficiency in 4bit scenarios.

I believe these additions will offer more versatility to the rulm project. I eagerly await your feedback and ready to make any necessary adjustments based on your suggestions.


